### PR TITLE
全屏后台安全局域导致的布局异常

### DIFF
--- a/SJBaseVideoPlayer.podspec
+++ b/SJBaseVideoPlayer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SJBaseVideoPlayer'
-  s.version      = '3.6.1'
+  s.version      = '3.6.2'
   s.summary      = 'video player.'
   s.description  = 'https://github.com/changsanjiang/SJBaseVideoPlayer/blob/master/README.md'
   s.homepage     = 'https://github.com/changsanjiang/SJBaseVideoPlayer'

--- a/SJBaseVideoPlayer/UIViewController+SJRotationPrivate_FixSafeArea.m
+++ b/SJBaseVideoPlayer/UIViewController+SJRotationPrivate_FixSafeArea.m
@@ -55,9 +55,9 @@ API_AVAILABLE(ios(13.0)) @implementation SJBaseVideoPlayer (SJRotationPrivate_Fi
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             Class cls = UIViewController.class;
-            NSData *data = [NSData.alloc initWithBase64EncodedString:@"c2V0Q29udGVudE92ZXJsYXlJbnNldHM6YW5kTGVmdE1hcmdpbjpyaWdodE1hcmdpbjo=" options:kNilOptions];
+            NSData *data = [NSData.alloc initWithBase64EncodedString:@"X3NldENvbnRlbnRPdmVybGF5SW5zZXRzOmFuZExlZnRNYXJnaW46cmlnaHRNYXJnaW46" options:kNilOptions];
             NSString *method = [NSString.alloc initWithData:data encoding:NSUTF8StringEncoding];
-            SEL originalSelector = sel_registerName(method.UTF8String);
+            SEL originalSelector = NSSelectorFromString(method);
             SEL swizzledSelector = @selector(sj_setContentOverlayInsets:andLeftMargin:rightMargin:);
             
             Method originalMethod = class_getInstanceMethod(cls, originalSelector);


### PR DESCRIPTION
本来`UIViewController+SJRotationPrivate_FixSafeArea.m`已有实现,

但是在iOS14的系统上发现hook的方法为 `setContentOverlayInsets:andLeftMargin:rightMargin:` 导致处理失效,

改为`_setContentOverlayInsets:andLeftMargin:rightMargin:` 即可解决.