### PR TITLE
Update SJAVMediaPlayerLoader.m

### DIFF
--- a/SJBaseVideoPlayer/AVPlayer/Core/SJAVMediaPlayerLoader.m
+++ b/SJBaseVideoPlayer/AVPlayer/Core/SJAVMediaPlayerLoader.m
@@ -29,6 +29,12 @@ static void *kPlayer = &kPlayer;
     AVPlayer *avPlayer = target.avPlayer;
     if ( avPlayer == nil ) {
         AVPlayerItem *avPlayerItem = target.avPlayerItem;
+        // 重新创建playerItem规避`An AVPlayerItem cannot be associated with more than one instance of AVPlayer`错误.
+        if (avPlayerItem != nil && avPlayerItem.status == AVPlayerStatusFailed) {
+            NSURL *url = [avPlayerItem valueForKey:@"_URL"];
+            avPlayerItem = [AVPlayerItem playerItemWithURL: url];
+            [target setValue:avPlayerItem forKey:@"avPlayerItem"];
+        }
         if ( avPlayerItem == nil ) {
             AVAsset *avAsset = target.avAsset;
             if ( avAsset == nil ) {


### PR DESCRIPTION
fix `An AVPlayerItem cannot be associated with more than one instance of AVPlayer`

 主要是为了解决弱网情况下,进行播放可能造成崩溃的问题.