### PR TITLE
Fix:修复阿里播放器暂停再播放 timeControlStatus 状态错误的问题

### DIFF
--- a/SJBaseVideoPlayer/AliPlayer/Core/SJAliMediaPlayer.m
+++ b/SJBaseVideoPlayer/AliPlayer/Core/SJAliMediaPlayer.m
@@ -443,6 +443,10 @@ NSErrorDomain const SJAliMediaPlayerErrorDomain = @"SJAliMediaPlayerErrorDomain"
             reason = nil;
             status = SJPlaybackTimeControlStatusPlaying;
         }
+        else if ( self.playerStatus == AVPStatusStarted ) {
+            reason = nil;
+            status = SJPlaybackTimeControlStatusPlaying;
+        }
         
         if ( status != self.timeControlStatus || reason != self.reasonForWaitingToPlay ) {
             self.reasonForWaitingToPlay = reason;


### PR DESCRIPTION
暂停播放之后 timeControlStatus 会被设置为 SJPlaybackTimeControlStatusWaitingToPlay
此时继续播放之前的判断条件不足以支持将 timeControlStatus 设置为 SJPlaybackTimeControlStatusPlaying ，因为此时的 eventType 为 AVPEventFirstRenderedStart
所以在此基础上增加 playerStatus 的条件，AVPStatusStarted 在阿里播放器中代表播放中的状态，这里没有没有额外判断 eventType == AVPEventFirstRenderedStart 的原因是因为首次播放时 eventType 是 AVPEventPrepareDone，目前测试下来没有问题