### PR TITLE
fix 16以下的系统, 如果当前界面是横屏,fitOn后是竖屏问题

### DIFF
--- a/SJBaseVideoPlayer/Common/Implements/SJFitOnScreenManager.m
+++ b/SJBaseVideoPlayer/Common/Implements/SJFitOnScreenManager.m
@@ -144,6 +144,8 @@ static NSNotificationName const SJFitOnScreenManagerTransitioningValueDidChangeN
         if ( fitOnScreen ) {
             UIViewController *top = [self topMostController];
             if ( !animated ) [self _presentedAnimationWithDuration:0 completionHandler:nil];
+            // 16以下的系统, 如果当前界面是横屏,fitOn后是竖屏问题
+            self.viewController.modalPresentationStyle = UIModalPresentationFullScreen;
             [top presentViewController:self.viewController animated:animated completion:^{
                 if ( completionHandler ) completionHandler(self);
             }];


### PR DESCRIPTION
如果app通过supportedInterfaceOrientations 来控制横竖屏, 当前界面是横屏,然后fitOn后是竖屏问题, 主要问题是 FitOn是present出来的, 16以上未发现问题,16以下发现均有问题,经测试是 控制器的 modalPresentationStyle 属性导致无法控制横屏, 设为fullScreen即可解决